### PR TITLE
Add handling of COAPS response codes

### DIFF
--- a/src/main/java/com/github/tradfrihttp/tradfricoaps/LightsHandler.java
+++ b/src/main/java/com/github/tradfrihttp/tradfricoaps/LightsHandler.java
@@ -38,6 +38,12 @@ public class LightsHandler {
         } catch (InterruptedException ie) {
             throw new TradfriCoapsApiException("No response from: " + uri, ie, HttpStatus.INTERNAL_SERVER_ERROR);
         }
+        if (response.getCode().equals(CoAP.ResponseCode.NOT_FOUND)) {
+            throw new TradfriCoapsApiException(String.format("Light with id \"%d\" not found", id), HttpStatus.NOT_FOUND);
+        }
+        if (!response.getCode().equals(CoAP.ResponseCode.CONTENT)) {
+            throw new TradfriCoapsApiException(String.format("Unexpected status code from gateway: %s", response.getCode()), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
         try {
             return new ObjectMapper().readValue(response.getPayload(), LightBulbIkea.class)
                     .toLightBulb();

--- a/src/test/java/com/github/tradfrihttp/tradfricoaps/GroupsHandlerTest.java
+++ b/src/test/java/com/github/tradfrihttp/tradfricoaps/GroupsHandlerTest.java
@@ -4,9 +4,11 @@ import com.github.tradfrihttp.model.LightGroup;
 import com.github.tradfrihttp.tradfricoaps.exceptions.TradfriCoapsApiException;
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.Response;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 
 import java.util.List;
 
@@ -22,38 +24,72 @@ public class GroupsHandlerTest {
 
     private GroupsHandler groupsHandler;
 
+    @BeforeEach
+    void setup() {
+        groupsHandler = new GroupsHandler(client, "some-gateway-ip", "8000");
+    }
+
     @Test
     void getGroupsShouldHandleValidResponse() throws InterruptedException, TradfriCoapsApiException {
-        Response mockResponse = new Response(CoAP.ResponseCode.VALID);
+        Response mockResponse = new Response(CoAP.ResponseCode.CONTENT);
         mockResponse.setPayload("[131073]");
         when(client.get(any())).thenReturn(mockResponse);
-        groupsHandler = new GroupsHandler(client, "some-gateway-ip", "8000");
         List<Integer> groupIds = groupsHandler.handleGetGroups();
         assertEquals(1, groupIds.size());
         assertEquals(131073, groupIds.get(0));
     }
 
     @Test
+    void getGroupsShouldHandleUnknownStatusCodes() throws InterruptedException {
+        Response mockResponse = new Response(CoAP.ResponseCode.INTERNAL_SERVER_ERROR);
+        when(client.get(any())).thenReturn(mockResponse);
+        try {
+            groupsHandler.handleGetGroups();
+        } catch (TradfriCoapsApiException tcai) {
+            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, tcai.getHttpStatus());
+        }
+    }
+
+    @Test
     void getGroupsShouldReturnEmptyList() throws InterruptedException, TradfriCoapsApiException {
-        Response mockResponse = new Response(CoAP.ResponseCode.VALID);
+        Response mockResponse = new Response(CoAP.ResponseCode.CONTENT);
         mockResponse.setPayload("[]");
         when(client.get(any())).thenReturn(mockResponse);
-        groupsHandler = new GroupsHandler(client, "some-gateway-ip", "8000");
         List<Integer> groupIds = groupsHandler.handleGetGroups();
         assertEquals(0, groupIds.size());
     }
 
     @Test
     void getGroupShouldHandleValidResponse() throws InterruptedException, TradfriCoapsApiException {
-        Response mockResponse = new Response(CoAP.ResponseCode.VALID);
+        Response mockResponse = new Response(CoAP.ResponseCode.CONTENT);
         mockResponse.setPayload("{\"9001\":\"Dunk\",\"9002\":1579467603,\"5851\":0,\"9003\":131073,\"5850\":0,\"9039\":196608,\"9108\":0,\"9018\":{\"15002\":{\"9003\":[65537,65538]}}}");
         when(client.get(any())).thenReturn(mockResponse);
-        groupsHandler = new GroupsHandler(client, "some-gateway-ip", "8000");
         LightGroup group = groupsHandler.handleGetGroup(0);
         assertEquals("Dunk", group.name);
         assertEquals(131073, group.id);
         assertEquals(65537, group.lightBulbs.get(0));
         assertEquals(65538, group.lightBulbs.get(1));
+    }
 
+    @Test
+    void getGroupShouldHandleNotFound() throws InterruptedException {
+        Response mockResponse = new Response(CoAP.ResponseCode.NOT_FOUND);
+        when(client.get(any())).thenReturn(mockResponse);
+        try {
+            groupsHandler.handleGetGroup(0);
+        } catch (TradfriCoapsApiException tcai) {
+            assertEquals(HttpStatus.NOT_FOUND, tcai.getHttpStatus());
+        }
+    }
+
+    @Test
+    void getGroupShouldHandleUnknownStatusCode() throws InterruptedException {
+        Response mockResponse = new Response(CoAP.ResponseCode.INTERNAL_SERVER_ERROR);
+        when(client.get(any())).thenReturn(mockResponse);
+        try {
+            groupsHandler.handleGetGroup(0);
+        } catch (TradfriCoapsApiException tcai) {
+            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, tcai.getHttpStatus());
+        }
     }
 }

--- a/src/test/java/com/github/tradfrihttp/tradfricoaps/LightsHandlerTest.java
+++ b/src/test/java/com/github/tradfrihttp/tradfricoaps/LightsHandlerTest.java
@@ -30,7 +30,7 @@ public class LightsHandlerTest {
 
     @Test
     void getLightShouldHandleValidResponse() throws InterruptedException, TradfriCoapsApiException {
-        Response mockResponse = new Response(CoAP.ResponseCode.VALID);
+        Response mockResponse = new Response(CoAP.ResponseCode.CONTENT);
         mockResponse.setPayload("{\"9001\":\"TRADFRI bulb\",\"9002\":1579467404,\"9020\":1580453223,\"9019\":1,\"9003\":65537,\"9054\":0,\"5750\":2,\"3\":{\"1\":\"TRADFRI bulb E14 WS opal 600lm\",\"0\":\"IKEA of Sweden\",\"2\":\"\",\"3\":\"2.0.023\",\"6\":1},\"3311\":[{\"5850\":1,\"9003\":0,\"5851\":137,\"5717\":0,\"5711\":370,\"5709\":32886,\"5710\":27217,\"5706\":\"f1e0b5\"}]}");
         when(client.get(any())).thenReturn(mockResponse);
         LightBulb lightBulb = lightsHandler.handleGetLight(0);
@@ -43,6 +43,28 @@ public class LightsHandlerTest {
         assertEquals(32886, lightBulb.xColor);
         assertEquals(27217, lightBulb.yColor);
         assertEquals("f1e0b5", lightBulb.hexColor);
+    }
+
+    @Test
+    void getLightShouldHandleNotFound() throws InterruptedException {
+        Response mockResponse = new Response(CoAP.ResponseCode.NOT_FOUND);
+        when(client.get(any())).thenReturn(mockResponse);
+        try {
+            lightsHandler.handleGetLight(0);
+        } catch (TradfriCoapsApiException tcai) {
+            assertEquals(HttpStatus.NOT_FOUND, tcai.getHttpStatus());
+        }
+    }
+
+    @Test
+    void getLightShouldHandleUnexpectedStatusCode() throws InterruptedException {
+        Response mockResponse = new Response(CoAP.ResponseCode.INTERNAL_SERVER_ERROR);
+        when(client.get(any())).thenReturn(mockResponse);
+        try {
+            lightsHandler.handleGetLight(0);
+        } catch (TradfriCoapsApiException tcai) {
+            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, tcai.getHttpStatus());
+        }
     }
 
     @Test


### PR DESCRIPTION
 - Check for expected response codes when communicating via COAPS
   - In HTTP API:
      - If not found response code, return 404
      - If expected response code, return 200
      - if other unexpected response code, return 500